### PR TITLE
Report more errors to Sentry

### DIFF
--- a/ttsmagic-server/src/importer.rs
+++ b/ttsmagic-server/src/importer.rs
@@ -234,6 +234,7 @@ ORDER BY user_id ASC, url ASC
             let url = match Url::parse(&url_str) {
                 Ok(u) => u,
                 Err(e) => {
+                    sentry::capture_error(&e);
                     error!("Failed to parse URL {:?} for deck {}: {}", url_str, id, e);
                     continue;
                 }

--- a/ttsmagic-server/src/main.rs
+++ b/ttsmagic-server/src/main.rs
@@ -53,6 +53,13 @@ fn setup_sentry(logger: Logger, dsn: Option<&str>) -> Option<sentry::ClientInitG
 
 #[async_std::main]
 async fn main() -> Result<()> {
+    main_inner().await.map_err(|e| {
+        sentry::integrations::anyhow::capture_anyhow(&e);
+        e
+    })
+}
+
+async fn main_inner() -> Result<()> {
     if let Err(e) = dotenv::dotenv() {
         eprintln!("Failed to get .env file: {}", e);
     };

--- a/ttsmagic-server/src/notify.rs
+++ b/ttsmagic-server/src/notify.rs
@@ -15,10 +15,9 @@ pub async fn notify_user<R: AsyncCommands>(
     let channel_name = user_channel_name(user);
     let serialized = serde_json::to_string(&msg)?;
     debug!("Sending notification to user {:?}: {:?}", user, msg);
-    match redis.publish::<_, _, i32>(&channel_name, serialized).await {
-        Ok(count) => debug!("Notification sent to {:?} listener(s)", count),
-        Err(e) => error!("Failed to publish notification! {}", e),
-    };
+    redis
+        .publish::<_, _, i32>(&channel_name, serialized)
+        .await?;
     Ok(())
 }
 

--- a/ttsmagic-server/src/scryfall.rs
+++ b/ttsmagic-server/src/scryfall.rs
@@ -204,10 +204,12 @@ RETURNING updated_at
         match inner() {
             Ok(names) => names,
             Err(e) => {
-                let id = self
-                    .id()
-                    .map(|id| format!("{}", id))
-                    .unwrap_or_else(|id_err| format!("<error getting ID: {}>", id_err));
+                let id: String = match self.id() {
+                    Ok(id) => id.to_string(),
+                    Err(e) => format!("<no card ID due to error: {:#}>", e),
+                };
+                let e = e.context(format!("Failed to get names for card with ID {}", id));
+                sentry::integrations::anyhow::capture_anyhow(&e);
                 error!("Got error when generating names for card {}: {}", id, e);
                 NonEmpty::singleton(format!("<error getting name for card {}>", id))
             }

--- a/ttsmagic-server/src/web.rs
+++ b/ttsmagic-server/src/web.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use async_std::{net::IpAddr, path::PathBuf, sync::Arc};
-use sentry::integrations::anyhow::capture_anyhow;
 
 mod app;
 mod deck;
@@ -35,8 +34,8 @@ async fn sentry_middleware(mut resp: tide::Response) -> tide::Result {
     if let Some(error) = resp.take_error() {
         let status = error.status();
         let inner = error.into_inner();
+        sentry::integrations::anyhow::capture_anyhow(&inner);
         error!("Tide view function returned {}: {}", status, inner);
-        capture_anyhow(&inner);
         let error = tide::Error::new(status, inner);
         resp.set_error(error);
     }

--- a/ttsmagic-server/src/web/deck.rs
+++ b/ttsmagic-server/src/web/deck.rs
@@ -31,7 +31,9 @@ pub async fn download_deck_json(req: Request<AppState>) -> Result {
                 Ok(x) => x,
                 Err(e) => {
                     error!($msg, $($arg,)* e);
-                    return Err(tide::Error::from_str(StatusCode::NotFound, "Invalid deck"));
+                    let e = anyhow::Error::from(e);
+                    let tide_error = tide::Error::new(StatusCode::NotFound, e.context("Invalid deck"));
+                    return Err(tide_error);
                 }
             }
         };


### PR DESCRIPTION
There are a number of exceptions that are logged with `log::error!`, but those only show the top level error, making it impossible to see the underlying cause. Reporting the errors with `sentry::capture_error` (and `capture_anyhow` as appropriate) should reveal the underlying causes.

This change tries to avoid capturing any errors that are propagated upwards, to avoid sending duplicate errors into Sentry.